### PR TITLE
Split worker main

### DIFF
--- a/app/src/main/java/mpc/project/ManagerMain.java
+++ b/app/src/main/java/mpc/project/ManagerMain.java
@@ -353,7 +353,7 @@ public class ManagerMain {
             System.out.println("Decrypted string: " + decryptedString);
             System.out.println(
                     "Decryption " +
-                    (decryptedString.equals(s) ? "successes!" : "fails!"));
+                            (decryptedString.equals(s) ? "successes!" : "fails!"));
         }
         System.exit(0);
     }

--- a/app/src/main/java/mpc/project/WorkerDataReceiver.java
+++ b/app/src/main/java/mpc/project/WorkerDataReceiver.java
@@ -1,0 +1,147 @@
+package mpc.project;
+
+import java.math.BigInteger;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class WorkerDataReceiver {
+    WorkerMain worker;
+    public WorkerDataReceiver(WorkerMain worker){
+        this.worker = worker;
+        this.primesReadyFlag.lock();
+        this.nPiecesReadyFlag.lock();
+        this.gammaReadyFlag.lock();
+        this.gammaSumReadyFlag.lock();
+        this.verificationFactorsReadyFlag.lock();
+        this.shadowsReadyFlag.lock();
+    }
+    public BigInteger[] pArr;          // An array holding p_i ( i \in [1, clusterNum])
+    public BigInteger[] qArr;          // An array holding q_i ( i \in [1, clusterNum])
+    public BigInteger[] hArr;          // An array holding h_i ( i \in [1, clusterNum])
+
+    public BigInteger[] nPieceArr;
+    public BigInteger[] gammaArr;
+    public BigInteger[] gammaSumArr;
+
+    public final Object exchangeGammaLock = new Object();
+    private Lock gammaReadyFlag = new ReentrantLock();
+    private int exchangeGammaCounter = 0;
+
+    public final Object exchangeGammaSumLock = new Object();
+    private Lock gammaSumReadyFlag = new ReentrantLock();
+    private int exchangeGammaSumCounter = 0;
+
+
+    public final Object exchangePrimesLock = new Object();
+    private Lock primesReadyFlag = new ReentrantLock();
+    private int exchangePrimesCounter = 0;
+
+    public final Object exchangeNPiecesLock = new Object();
+    private Lock nPiecesReadyFlag = new ReentrantLock();
+    private int exchangeNPiecesCounter = 0;
+
+    private final Object shadowReceivingLock = new Object();
+    private Lock shadowsReadyFlag = new ReentrantLock();
+    private int shadowReceivingCounter = 0;
+
+    private final Object verificationFactorsLock = new Object();
+    private Lock verificationFactorsReadyFlag = new ReentrantLock();
+    private int verificationFactorsCounter = 0;
+
+    public void receivePHQ(int id, BigInteger p, BigInteger q, BigInteger h){
+        int i = id - 1;
+        pArr[i] = p;
+        qArr[i] = q;
+        hArr[i] = h;
+        synchronized (exchangePrimesLock) {
+            exchangePrimesCounter++;
+            if (exchangePrimesCounter == worker.getClusterSize()) {
+                primesReadyFlag.unlock();
+                exchangePrimesCounter = 0;
+            }
+        }
+    }
+
+    public void waitPHQ(){
+        primesReadyFlag.lock();
+    }
+
+    public void receiveNPiece(int id, BigInteger nPiece){
+        int i = id - 1;
+        nPieceArr[i] = nPiece;
+        synchronized (exchangeNPiecesLock){
+            exchangeNPiecesCounter++;
+            if(exchangeNPiecesCounter == worker.getClusterSize()){
+                nPiecesReadyFlag.unlock();
+                exchangeNPiecesCounter = 0;
+            }
+        }
+    }
+
+    public void waitNPieces(){
+        nPiecesReadyFlag.lock();
+    }
+
+    public void receiveGamma(int id, BigInteger gamma){
+        int i = id - 1;
+        gammaArr[i] = gamma;
+        synchronized (exchangeGammaLock){
+            exchangeGammaCounter++;
+            if(exchangeGammaCounter == worker.getClusterSize()){
+                gammaReadyFlag.unlock();
+                exchangeGammaCounter = 0;
+            }
+        }
+    }
+
+    public void waitGamma(){
+        gammaReadyFlag.lock();
+    }
+
+    public void receiveGammaSum(int id, BigInteger gammaSum){
+        int i = id - 1;
+        gammaSumArr[i] = gammaSum;
+        synchronized (exchangeGammaSumLock){
+            exchangeGammaSumCounter++;
+            if(exchangeGammaSumCounter == worker.getClusterSize()){
+                gammaSumReadyFlag.unlock();
+                exchangeGammaSumCounter = 0;
+            }
+        }
+    }
+
+    public void waitGammaSum(){
+        gammaSumReadyFlag.lock();
+    }
+
+    public void receiveShadow(int id, String factor, String[] resultBucket){
+        int j = id - 1;
+        resultBucket[j] = factor;
+        synchronized (shadowReceivingLock) {
+            shadowReceivingCounter++;
+            if (shadowReceivingCounter == worker.getClusterSize()) {
+                shadowsReadyFlag.unlock();
+            }
+        }
+    }
+
+    public void waitShadows(){
+        shadowsReadyFlag.lock();
+    }
+
+    public void receiveVerificationFactor(int id, BigInteger factor, BigInteger[] resultBucket){
+        int j = id - 1;
+        resultBucket[j] = factor;
+        synchronized (verificationFactorsLock) {
+            verificationFactorsCounter++;
+            if (verificationFactorsCounter == worker.getClusterSize()) {
+                verificationFactorsReadyFlag.unlock();
+            }
+        }
+    }
+
+    public void waitVerificationFactors(){
+        verificationFactorsReadyFlag.lock();
+    }
+}

--- a/app/src/main/java/mpc/project/WorkerDataReceiver.java
+++ b/app/src/main/java/mpc/project/WorkerDataReceiver.java
@@ -7,7 +7,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class WorkerDataReceiver {
     WorkerMain worker;
-    public WorkerDataReceiver(WorkerMain worker){
+
+    public WorkerDataReceiver(WorkerMain worker) {
         this.worker = worker;
         try {
             this.primesReadyFlag.acquire();
@@ -20,6 +21,7 @@ public class WorkerDataReceiver {
             e.printStackTrace();
         }
     }
+
     public BigInteger[] pArr;          // An array holding p_i ( i \in [1, clusterNum])
     public BigInteger[] qArr;          // An array holding q_i ( i \in [1, clusterNum])
     public BigInteger[] hArr;          // An array holding h_i ( i \in [1, clusterNum])
@@ -29,7 +31,7 @@ public class WorkerDataReceiver {
     public BigInteger[] gammaSumArr;
 
     public final Object exchangeGammaLock = new Object();
-//    private Lock gammaReadyFlag = new ReentrantLock();
+    //    private Lock gammaReadyFlag = new ReentrantLock();
     private final Semaphore gammaReadyFlag = new Semaphore(1);
     private int exchangeGammaCounter = 0;
 
@@ -54,7 +56,7 @@ public class WorkerDataReceiver {
     private final Semaphore verificationFactorsReadyFlag = new Semaphore(1);
     private int verificationFactorsCounter = 0;
 
-    public void receivePHQ(int id, BigInteger p, BigInteger q, BigInteger h){
+    public void receivePHQ(int id, BigInteger p, BigInteger q, BigInteger h) {
         int i = id - 1;
         pArr[i] = p;
         qArr[i] = q;
@@ -68,7 +70,7 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void waitPHQ(){
+    public void waitPHQ() {
         try {
             primesReadyFlag.acquire();
         } catch (InterruptedException e) {
@@ -76,19 +78,19 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void receiveNPiece(int id, BigInteger nPiece){
+    public void receiveNPiece(int id, BigInteger nPiece) {
         int i = id - 1;
         nPieceArr[i] = nPiece;
-        synchronized (exchangeNPiecesLock){
+        synchronized (exchangeNPiecesLock) {
             exchangeNPiecesCounter++;
-            if(exchangeNPiecesCounter == worker.getClusterSize()){
+            if (exchangeNPiecesCounter == worker.getClusterSize()) {
                 nPiecesReadyFlag.release();
                 exchangeNPiecesCounter = 0;
             }
         }
     }
 
-    public void waitNPieces(){
+    public void waitNPieces() {
         try {
             nPiecesReadyFlag.acquire();
         } catch (InterruptedException e) {
@@ -96,19 +98,19 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void receiveGamma(int id, BigInteger gamma){
+    public void receiveGamma(int id, BigInteger gamma) {
         int i = id - 1;
         gammaArr[i] = gamma;
-        synchronized (exchangeGammaLock){
+        synchronized (exchangeGammaLock) {
             exchangeGammaCounter++;
-            if(exchangeGammaCounter == worker.getClusterSize()){
+            if (exchangeGammaCounter == worker.getClusterSize()) {
                 gammaReadyFlag.release();
                 exchangeGammaCounter = 0;
             }
         }
     }
 
-    public void waitGamma(){
+    public void waitGamma() {
         try {
             gammaReadyFlag.acquire();
         } catch (InterruptedException e) {
@@ -116,19 +118,19 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void receiveGammaSum(int id, BigInteger gammaSum){
+    public void receiveGammaSum(int id, BigInteger gammaSum) {
         int i = id - 1;
         gammaSumArr[i] = gammaSum;
-        synchronized (exchangeGammaSumLock){
+        synchronized (exchangeGammaSumLock) {
             exchangeGammaSumCounter++;
-            if(exchangeGammaSumCounter == worker.getClusterSize()){
+            if (exchangeGammaSumCounter == worker.getClusterSize()) {
                 gammaSumReadyFlag.release();
                 exchangeGammaSumCounter = 0;
             }
         }
     }
 
-    public void waitGammaSum(){
+    public void waitGammaSum() {
         try {
             gammaSumReadyFlag.acquire();
         } catch (InterruptedException e) {
@@ -136,7 +138,7 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void receiveShadow(int id, String factor, String[] resultBucket){
+    public void receiveShadow(int id, String factor, String[] resultBucket) {
         int j = id - 1;
         resultBucket[j] = factor;
         synchronized (shadowReceivingLock) {
@@ -148,7 +150,7 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void waitShadows(){
+    public void waitShadows() {
         try {
             shadowsReadyFlag.acquire();
         } catch (InterruptedException e) {
@@ -156,7 +158,7 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void receiveVerificationFactor(int id, BigInteger factor, BigInteger[] resultBucket){
+    public void receiveVerificationFactor(int id, BigInteger factor, BigInteger[] resultBucket) {
         int j = id - 1;
         resultBucket[j] = factor;
         synchronized (verificationFactorsLock) {
@@ -168,7 +170,7 @@ public class WorkerDataReceiver {
         }
     }
 
-    public void waitVerificationFactors(){
+    public void waitVerificationFactors() {
         try {
             verificationFactorsReadyFlag.acquire();
         } catch (InterruptedException e) {

--- a/app/src/main/java/mpc/project/WorkerDataReceiver.java
+++ b/app/src/main/java/mpc/project/WorkerDataReceiver.java
@@ -30,28 +30,28 @@ public class WorkerDataReceiver {
 
     public final Object exchangeGammaLock = new Object();
 //    private Lock gammaReadyFlag = new ReentrantLock();
-    private Semaphore gammaReadyFlag = new Semaphore(1);
+    private final Semaphore gammaReadyFlag = new Semaphore(1);
     private int exchangeGammaCounter = 0;
 
     public final Object exchangeGammaSumLock = new Object();
-    private Semaphore gammaSumReadyFlag = new Semaphore(1);
+    private final Semaphore gammaSumReadyFlag = new Semaphore(1);
     private int exchangeGammaSumCounter = 0;
 
 
     public final Object exchangePrimesLock = new Object();
-    private Semaphore primesReadyFlag = new Semaphore(1);
+    private final Semaphore primesReadyFlag = new Semaphore(1);
     private int exchangePrimesCounter = 0;
 
     public final Object exchangeNPiecesLock = new Object();
-    private Semaphore nPiecesReadyFlag = new Semaphore(1);
+    private final Semaphore nPiecesReadyFlag = new Semaphore(1);
     private int exchangeNPiecesCounter = 0;
 
     private final Object shadowReceivingLock = new Object();
-    private Semaphore shadowsReadyFlag = new Semaphore(1);
+    private final Semaphore shadowsReadyFlag = new Semaphore(1);
     private int shadowReceivingCounter = 0;
 
     private final Object verificationFactorsLock = new Object();
-    private Semaphore verificationFactorsReadyFlag = new Semaphore(1);
+    private final Semaphore verificationFactorsReadyFlag = new Semaphore(1);
     private int verificationFactorsCounter = 0;
 
     public void receivePHQ(int id, BigInteger p, BigInteger q, BigInteger h){
@@ -143,6 +143,7 @@ public class WorkerDataReceiver {
             shadowReceivingCounter++;
             if (shadowReceivingCounter == worker.getClusterSize()) {
                 shadowsReadyFlag.release();
+                shadowReceivingCounter = 0;
             }
         }
     }
@@ -162,6 +163,7 @@ public class WorkerDataReceiver {
             verificationFactorsCounter++;
             if (verificationFactorsCounter == worker.getClusterSize()) {
                 verificationFactorsReadyFlag.release();
+                verificationFactorsCounter = 0;
             }
         }
     }

--- a/app/src/main/java/mpc/project/WorkerDataReceiver.java
+++ b/app/src/main/java/mpc/project/WorkerDataReceiver.java
@@ -2,8 +2,6 @@ package mpc.project;
 
 import java.math.BigInteger;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class WorkerDataReceiver {
     WorkerMain worker;

--- a/app/src/main/java/mpc/project/WorkerDataReceiver.java
+++ b/app/src/main/java/mpc/project/WorkerDataReceiver.java
@@ -9,12 +9,16 @@ public class WorkerDataReceiver {
     WorkerMain worker;
     public WorkerDataReceiver(WorkerMain worker){
         this.worker = worker;
-        this.primesReadyFlag.lock();
-        this.nPiecesReadyFlag.lock();
-        this.gammaReadyFlag.lock();
-        this.gammaSumReadyFlag.lock();
-        this.verificationFactorsReadyFlag.lock();
-        this.shadowsReadyFlag.lock();
+        try {
+            this.primesReadyFlag.acquire();
+            this.nPiecesReadyFlag.acquire();
+            this.gammaReadyFlag.acquire();
+            this.gammaSumReadyFlag.acquire();
+            this.verificationFactorsReadyFlag.acquire();
+            this.shadowsReadyFlag.acquire();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
     public BigInteger[] pArr;          // An array holding p_i ( i \in [1, clusterNum])
     public BigInteger[] qArr;          // An array holding q_i ( i \in [1, clusterNum])
@@ -25,28 +29,29 @@ public class WorkerDataReceiver {
     public BigInteger[] gammaSumArr;
 
     public final Object exchangeGammaLock = new Object();
-    private Lock gammaReadyFlag = new ReentrantLock();
+//    private Lock gammaReadyFlag = new ReentrantLock();
+    private Semaphore gammaReadyFlag = new Semaphore(1);
     private int exchangeGammaCounter = 0;
 
     public final Object exchangeGammaSumLock = new Object();
-    private Lock gammaSumReadyFlag = new ReentrantLock();
+    private Semaphore gammaSumReadyFlag = new Semaphore(1);
     private int exchangeGammaSumCounter = 0;
 
 
     public final Object exchangePrimesLock = new Object();
-    private Lock primesReadyFlag = new ReentrantLock();
+    private Semaphore primesReadyFlag = new Semaphore(1);
     private int exchangePrimesCounter = 0;
 
     public final Object exchangeNPiecesLock = new Object();
-    private Lock nPiecesReadyFlag = new ReentrantLock();
+    private Semaphore nPiecesReadyFlag = new Semaphore(1);
     private int exchangeNPiecesCounter = 0;
 
     private final Object shadowReceivingLock = new Object();
-    private Lock shadowsReadyFlag = new ReentrantLock();
+    private Semaphore shadowsReadyFlag = new Semaphore(1);
     private int shadowReceivingCounter = 0;
 
     private final Object verificationFactorsLock = new Object();
-    private Lock verificationFactorsReadyFlag = new ReentrantLock();
+    private Semaphore verificationFactorsReadyFlag = new Semaphore(1);
     private int verificationFactorsCounter = 0;
 
     public void receivePHQ(int id, BigInteger p, BigInteger q, BigInteger h){
@@ -57,14 +62,18 @@ public class WorkerDataReceiver {
         synchronized (exchangePrimesLock) {
             exchangePrimesCounter++;
             if (exchangePrimesCounter == worker.getClusterSize()) {
-                primesReadyFlag.unlock();
+                primesReadyFlag.release();
                 exchangePrimesCounter = 0;
             }
         }
     }
 
     public void waitPHQ(){
-        primesReadyFlag.lock();
+        try {
+            primesReadyFlag.acquire();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void receiveNPiece(int id, BigInteger nPiece){
@@ -73,14 +82,18 @@ public class WorkerDataReceiver {
         synchronized (exchangeNPiecesLock){
             exchangeNPiecesCounter++;
             if(exchangeNPiecesCounter == worker.getClusterSize()){
-                nPiecesReadyFlag.unlock();
+                nPiecesReadyFlag.release();
                 exchangeNPiecesCounter = 0;
             }
         }
     }
 
     public void waitNPieces(){
-        nPiecesReadyFlag.lock();
+        try {
+            nPiecesReadyFlag.acquire();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void receiveGamma(int id, BigInteger gamma){
@@ -89,14 +102,18 @@ public class WorkerDataReceiver {
         synchronized (exchangeGammaLock){
             exchangeGammaCounter++;
             if(exchangeGammaCounter == worker.getClusterSize()){
-                gammaReadyFlag.unlock();
+                gammaReadyFlag.release();
                 exchangeGammaCounter = 0;
             }
         }
     }
 
     public void waitGamma(){
-        gammaReadyFlag.lock();
+        try {
+            gammaReadyFlag.acquire();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void receiveGammaSum(int id, BigInteger gammaSum){
@@ -105,14 +122,18 @@ public class WorkerDataReceiver {
         synchronized (exchangeGammaSumLock){
             exchangeGammaSumCounter++;
             if(exchangeGammaSumCounter == worker.getClusterSize()){
-                gammaSumReadyFlag.unlock();
+                gammaSumReadyFlag.release();
                 exchangeGammaSumCounter = 0;
             }
         }
     }
 
     public void waitGammaSum(){
-        gammaSumReadyFlag.lock();
+        try {
+            gammaSumReadyFlag.acquire();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void receiveShadow(int id, String factor, String[] resultBucket){
@@ -121,13 +142,17 @@ public class WorkerDataReceiver {
         synchronized (shadowReceivingLock) {
             shadowReceivingCounter++;
             if (shadowReceivingCounter == worker.getClusterSize()) {
-                shadowsReadyFlag.unlock();
+                shadowsReadyFlag.release();
             }
         }
     }
 
     public void waitShadows(){
-        shadowsReadyFlag.lock();
+        try {
+            shadowsReadyFlag.acquire();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void receiveVerificationFactor(int id, BigInteger factor, BigInteger[] resultBucket){
@@ -136,12 +161,16 @@ public class WorkerDataReceiver {
         synchronized (verificationFactorsLock) {
             verificationFactorsCounter++;
             if (verificationFactorsCounter == worker.getClusterSize()) {
-                verificationFactorsReadyFlag.unlock();
+                verificationFactorsReadyFlag.release();
             }
         }
     }
 
     public void waitVerificationFactors(){
-        verificationFactorsReadyFlag.lock();
+        try {
+            verificationFactorsReadyFlag.acquire();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/app/src/main/java/mpc/project/WorkerMain.java
+++ b/app/src/main/java/mpc/project/WorkerMain.java
@@ -1,7 +1,6 @@
 package mpc.project;
 
 import io.grpc.*;
-import io.grpc.stub.StreamObserver;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -9,28 +8,54 @@ import java.math.RoundingMode;
 import java.util.Random;
 
 import mpc.project.util.Key;
-import mpc.project.util.RpcUtility;
 import mpc.project.util.MathUtility;
 import mpc.project.util.RSA;
 
 public class WorkerMain {
     private Server server;
+    private WorkerRPCSender rpcSender;
+    public WorkerRPCSender getRpcSender(){
+        return rpcSender;
+    }
+    private WorkerDataReceiver dataReceiver;
+
+    public WorkerDataReceiver getDataReceiver() {
+        return dataReceiver;
+    }
+
     private final int portNum;
     private int id;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
     private final Random rnd;
-    private int bitNum;
-    private String[] addressBook;
-    private int clusterSize;
+
     private WorkerServiceGrpc.WorkerServiceStub[] stubs;
+    private int clusterSize;
+
+    public void setClusterSize(int clusterSize) {
+        this.clusterSize = clusterSize;
+        dataBucketInit();
+    }
+
+    public int getClusterSize(){
+        return clusterSize;
+    }
+
     private ManagerServiceGrpc.ManagerServiceBlockingStub managerStub;
 
     /* Variables for distributed RSA keypair generation */
-    private BigInteger randomPrime;
     private BigInteger p;
     private BigInteger q;
-    BigInteger[] pArr;          // An array holding p_i ( i \in [1, clusterNum])
-    BigInteger[] qArr;          // An array holding q_i ( i \in [1, clusterNum])
-    BigInteger[] hArr;          // An array holding h_i ( i \in [1, clusterNum])
+    private BigInteger[] pArr;          // An array holding p_i ( i \in [1, clusterNum])
+    private BigInteger[] qArr;          // An array holding q_i ( i \in [1, clusterNum])
+    private BigInteger[] hArr;          // An array holding h_i ( i \in [1, clusterNum])
     private BigInteger[] nPieceArr;
 
     /* Rsa Key
@@ -39,170 +64,8 @@ public class WorkerMain {
      *    private key: <d, N>
      */
     private Key key = new Key();
-
-    /* Locks for synchronization between workers */
-    // Todo: find a more elegant way to implement synchronization
-    private final Object exchangePrimesLock = new Object();
-    private int exchangePrimesWorkersCounter = 0;
-
-    private final Object exchangeNPiecesLock = new Object();
-    private int exchangeNPiecesWorkersCounter = 0;
-
-    private final Object modulusGenerationLock = new Object();
-
-    class WorkerServiceImpl extends WorkerServiceGrpc.WorkerServiceImplBase {
-        @Override
-        public void formCluster(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-//            id = request.getId();
-//            randomPrime = new BigInteger(request.getContents().toByteArray());
-            StdResponse res = RpcUtility.Response.newStdResponse(id);
-            responseObserver.onNext(res);
-            responseObserver.onCompleted();
-            System.out.println("connected to Manager");
-        }
-
-        @Override
-        public void formNetwork(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            String midString = new String(request.getContents().toByteArray());
-            addressBook = midString.split(";");
-            StdResponse response = RpcUtility.Response.newStdResponse(id);
-            stubs = new WorkerServiceGrpc.WorkerServiceStub[addressBook.length];
-            System.out.println("received and parsed addressBook: ");
-            for (int i = 0; i < addressBook.length; i++) {
-                System.out.println(addressBook[i]);
-                Channel channel = ManagedChannelBuilder.forTarget(addressBook[i]).usePlaintext().build();
-                stubs[i] = WorkerServiceGrpc.newStub(channel);
-            }
-            clusterSize = addressBook.length;
-            keyGenerationArrayInit();
-            responseObserver.onNext(response);
-            responseObserver.onCompleted();
-        }
-
-        @Override
-        public void registerManager(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            id = request.getId();
-            String managerUri = new String(request.getContents().toByteArray());
-            Channel channel = ManagedChannelBuilder.forTarget(managerUri).usePlaintext().build();
-            managerStub = ManagerServiceGrpc.newBlockingStub(channel);
-            StdRequest greetingReq = RpcUtility.Request.newStdRequest(id);
-            managerStub.greeting(greetingReq);
-            responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
-            responseObserver.onCompleted();
-            System.out.println("registered manager at " + managerUri);
-        }
-
-        @Override
-        public void generateModulusPiece(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            synchronized (modulusGenerationLock) {
-                // id is used for bitNum now, not id
-                bitNum = request.getId();
-                randomPrime = new BigInteger(request.getContents().toByteArray());
-//                p = genRandPrimeBig(bitNum, randomPrime, rnd);
-                p = BigInteger.probablePrime(bitNum, rnd);
-//                q = genRandPrimeBig(bitNum, randomPrime, rnd);
-                q = BigInteger.probablePrime(bitNum, rnd);
-                WorkerMain.this.generateModulusPiece();
-                responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
-                responseObserver.onCompleted();
-            }
-        }
-
-        @Override
-        public void exchangePrimesPQH(ExchangePrimespqhRequest request, StreamObserver<StdResponse> responseObserver) {
-            synchronized (exchangePrimesLock) {
-                int i = request.getId() - 1;
-//                System.out.println("receiving " + i + " prime p q h");
-                pArr[i] = new BigInteger(request.getP().toByteArray());
-                qArr[i] = new BigInteger(request.getQ().toByteArray());
-                hArr[i] = new BigInteger(request.getH().toByteArray());
-                responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
-                responseObserver.onCompleted();
-                exchangePrimesWorkersCounter++;
-                if (exchangePrimesWorkersCounter == 2 * clusterSize) {
-                    exchangePrimesLock.notify();
-                }
-            }
-        }
-
-        @Override
-        public void exchangeNPiece(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            synchronized (exchangeNPiecesLock) {
-                int i = request.getId() - 1;
-//                System.out.println("receiving " + i + " N piece");
-                nPieceArr[i] = new BigInteger(request.getContents().toByteArray());
-                responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
-                responseObserver.onCompleted();
-                exchangeNPiecesWorkersCounter++;
-                if (exchangeNPiecesWorkersCounter == 2 * clusterSize) {
-                    exchangeNPiecesLock.notify();
-                }
-            }
-        }
-
-        @Override
-        public void primalityTest(StdRequest request, StreamObserver<PrimalityTestResponse> responseObserver) {
-//            System.out.println("receive primalityTest RPC");
-            if (id == 1 && !primalityTestWaiting) {
-                boolean passPrimalityTest = primalityTestHost();
-                PrimalityTestResponse response;
-                if (passPrimalityTest) {
-                    response = RpcUtility.Response.newPrimalityTestResponse(1);
-                } else {
-                    response = RpcUtility.Response.newPrimalityTestResponse(0);
-                }
-                responseObserver.onNext(response);
-            } else {
-                BigInteger result = primalityTestGuest(new BigInteger(request.getContents().toByteArray()));
-                responseObserver.onNext(RpcUtility.Response.newPrimalityTestResponse(id, result));
-            }
-            responseObserver.onCompleted();
-        }
-
-        @Override
-        public void exchangeGamma(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            synchronized (exchangeGammaLock) {
-                int i = request.getId() - 1;
-                BigInteger gamma = new BigInteger(request.getContents().toByteArray());
-                gammaArr[i] = gamma;
-                responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
-                responseObserver.onCompleted();
-                exchangeGammaCounter++;
-                if (exchangeGammaCounter == 2 * clusterSize) {
-                    exchangeGammaLock.notify();
-                }
-            }
-        }
-
-        @Override
-        public void exchangeGammaSum(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            synchronized (exchangeGammaSumLock) {
-                int i = request.getId() - 1;
-                BigInteger gammaSum = new BigInteger(request.getContents().toByteArray());
-                gammaSumArr[i] = gammaSum;
-                responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
-                responseObserver.onCompleted();
-                exchangeGammaSumCounter++;
-                if (exchangeGammaSumCounter == 2 * clusterSize) {
-                    exchangeGammaSumLock.notify();
-                }
-            }
-        }
-
-        @Override
-        public void generatePrivateKey(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            WorkerMain.this.generatePrivateKey();
-            responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
-            responseObserver.onCompleted();
-        }
-
-        @Override
-        public void decrypt(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-            String encryptedString = new String(request.getContents().toByteArray());
-            String shadow = RSA.localDecrypt(encryptedString, key);
-            responseObserver.onNext(RpcUtility.Response.newStdResponse(id, shadow));
-            responseObserver.onCompleted();
-        }
+    public Key getKey(){
+        return key;
     }
 
     public WorkerMain(int portNum) {
@@ -211,9 +74,11 @@ public class WorkerMain {
     }
 
     public void run() {
+        this.rpcSender = new WorkerRPCSender(this);
+        this.dataReceiver = new WorkerDataReceiver(this);
         try {
             this.server = ServerBuilder.forPort(portNum)
-                    .addService(new WorkerServiceImpl())
+                    .addService(new WorkerRPCReceiverService(this))
                     .build().start();
             System.out.println("Waiting for manager to connect");
             this.server.awaitTermination();
@@ -227,148 +92,88 @@ public class WorkerMain {
         }
     }
 
-    private void keyGenerationArrayInit() {
+    private void dataBucketInit() {
         pArr = new BigInteger[clusterSize];
         qArr = new BigInteger[clusterSize];
         hArr = new BigInteger[clusterSize];
         nPieceArr = new BigInteger[clusterSize];
         gammaArr = new BigInteger[clusterSize];
         gammaSumArr = new BigInteger[clusterSize];
+
+        dataReceiver.pArr = this.pArr;
+        dataReceiver.qArr = this.qArr;
+        dataReceiver.hArr = this.hArr;
+        dataReceiver.nPieceArr = this.nPieceArr;
+        dataReceiver.gammaArr = this.gammaArr;
+        dataReceiver.gammaSumArr = this.gammaSumArr;
     }
 
-    private void generateModulusPiece() {
-        generateFGH();
-    }
-
-    private void generateFGH() {
-        synchronized (exchangePrimesLock) {
-            int l = (clusterSize - 1) / 2;
-
-            BigInteger[] polyF = new BigInteger[l];
-            polyF[0] = p;
-            for (int i = 1; i < polyF.length; i++) {
-                polyF[i] = MathUtility.genRandBig(randomPrime, rnd);
-            }
-
-            BigInteger[] polyG = new BigInteger[l];
-            polyG[0] = q;
-            for (int i = 1; i < polyG.length; i++) {
-                polyG[i] = MathUtility.genRandBig(randomPrime, rnd);
-            }
-
-            BigInteger[] polyH = new BigInteger[2 * l];
-            polyH[0] = BigInteger.valueOf(0);
-            for (int i = 1; i < polyH.length; i++) {
-                polyH[i] = MathUtility.genRandBig(randomPrime, rnd);
-            }
-
-            BigInteger[] pArr_tmp = new BigInteger[clusterSize];
-            for (int i = 0; i < clusterSize; i++) {
-                pArr_tmp[i] = MathUtility.polynomialResult(polyF, BigInteger.valueOf(i + 1));
-            }
-
-            BigInteger[] qArr_tmp = new BigInteger[clusterSize];
-            for (int i = 0; i < clusterSize; i++) {
-                qArr_tmp[i] = MathUtility.polynomialResult(polyG, BigInteger.valueOf(i + 1));
-            }
-
-            BigInteger[] hArr_tmp = new BigInteger[clusterSize];
-            for (int i = 0; i < clusterSize; i++) {
-                hArr_tmp[i] = MathUtility.polynomialResult(polyH, BigInteger.valueOf(i + 1));
-            }
-
-            // Wait to receive all p q h
-            for (int i = 1; i <= clusterSize; i++) {
-                sendPQH(i, pArr_tmp[i - 1], qArr_tmp[i - 1], hArr_tmp[i - 1]);
-            }
-            if (exchangePrimesWorkersCounter < 2 * clusterSize) {
-                try {
-                    exchangePrimesLock.wait();
-                } catch (Exception e) {
-                    System.out.println(e.getMessage());
-                    System.exit(-1);
-                }
-            }
+    private final Object modulusGenerationLock = new Object();
+    public void generateModulusPiece(int bitNum, BigInteger randomPrime) {
+        synchronized (modulusGenerationLock){
+            p = BigInteger.probablePrime(bitNum, rnd);
+            q = BigInteger.probablePrime(bitNum, rnd);
+            generateFGH(randomPrime);
+            generateNPiece(randomPrime);
+            generateN(randomPrime);
         }
-        exchangePrimesWorkersCounter = 0;
-        generateNPiece();
     }
 
-    private void sendPQH(int i, BigInteger p, BigInteger q, BigInteger h) {
-        ExchangePrimespqhRequest request = RpcUtility.Request.newExchangePrimesRequest(this.id, p, q, h);
-        stubs[i - 1].exchangePrimesPQH(request, new StreamObserver<>() {
-            @Override
-            public void onNext(StdResponse response) {
-            }
+    private void generateFGH(BigInteger randomPrime) {
+        int l = (clusterSize - 1) / 2;
 
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("exchangePQH RPC error for " + i + " : " + t.getMessage());
-                System.exit(-1);
-            }
-
-            @Override
-            public void onCompleted() {
-//                System.out.println("sent!");
-                synchronized (exchangePrimesLock) {
-                    exchangePrimesWorkersCounter++;
-                    if (exchangePrimesWorkersCounter == 2 * clusterSize) {
-                        exchangePrimesLock.notify();
-                    }
-                }
-            }
-        });
-    }
-
-    private void sendNPiece(int i, BigInteger nPiece) {
-        StdRequest request = RpcUtility.Request.newStdRequest(this.id, nPiece);
-        stubs[i - 1].exchangeNPiece(request, new StreamObserver<StdResponse>() {
-            @Override
-            public void onNext(StdResponse response) {
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("sendNPiece RPC error for " + i + " : " + t.getMessage());
-                System.exit(-1);
-            }
-
-            @Override
-            public void onCompleted() {
-//                System.out.println("sent!");
-                synchronized (exchangeNPiecesLock) {
-                    exchangeNPiecesWorkersCounter++;
-                    if (exchangeNPiecesWorkersCounter == 2 * clusterSize) {
-                        exchangeNPiecesLock.notify();
-                    }
-                }
-            }
-        });
-    }
-
-    private void generateNPiece() {
-        synchronized (exchangeNPiecesLock) {
-            BigInteger nPiece = (MathUtility.arraySum(pArr)
-                    .multiply(MathUtility.arraySum(qArr)))
-                    .add(MathUtility.arraySum(hArr))
-                    .mod(randomPrime);
-            for (int i = 1; i <= clusterSize; i++) {
-                sendNPiece(i, nPiece);
-            }
-            if (exchangeNPiecesWorkersCounter < 2 * clusterSize) {
-                try {
-                    exchangeNPiecesLock.wait();
-                } catch (Exception e) {
-                    System.out.println(e.getMessage());
-                    System.exit(-1);
-                }
-            }
+        BigInteger[] polyF = new BigInteger[l];
+        polyF[0] = p;
+        for (int i = 1; i < polyF.length; i++) {
+            polyF[i] = MathUtility.genRandBig(randomPrime, rnd);
         }
-        exchangeNPiecesWorkersCounter = 0;
-        generateN();
+
+        BigInteger[] polyG = new BigInteger[l];
+        polyG[0] = q;
+        for (int i = 1; i < polyG.length; i++) {
+            polyG[i] = MathUtility.genRandBig(randomPrime, rnd);
+        }
+
+        BigInteger[] polyH = new BigInteger[2 * l];
+        polyH[0] = BigInteger.valueOf(0);
+        for (int i = 1; i < polyH.length; i++) {
+            polyH[i] = MathUtility.genRandBig(randomPrime, rnd);
+        }
+
+        BigInteger[] pArr_tmp = new BigInteger[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            pArr_tmp[i] = MathUtility.polynomialResult(polyF, BigInteger.valueOf(i + 1));
+        }
+
+        BigInteger[] qArr_tmp = new BigInteger[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            qArr_tmp[i] = MathUtility.polynomialResult(polyG, BigInteger.valueOf(i + 1));
+        }
+
+        BigInteger[] hArr_tmp = new BigInteger[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            hArr_tmp[i] = MathUtility.polynomialResult(polyH, BigInteger.valueOf(i + 1));
+        }
+
+        // Wait to receive all p q h
+        for (int i = 1; i <= clusterSize; i++) {
+            rpcSender.sendPQH(i, pArr_tmp[i - 1], qArr_tmp[i - 1], hArr_tmp[i - 1]);
+        }
     }
 
-    private void generateN() {
+    private void generateNPiece(BigInteger randomPrime) {
+        dataReceiver.waitPHQ();
+        BigInteger nPiece = (MathUtility.arraySum(pArr)
+                .multiply(MathUtility.arraySum(qArr)))
+                .add(MathUtility.arraySum(hArr))
+                .mod(randomPrime);
+        for (int i = 1; i <= clusterSize; i++) {
+            rpcSender.sendNPiece(i, nPiece);
+        }
+    }
+
+    private void generateN(BigInteger randomPrime) {
+        dataReceiver.waitNPieces();
         double[] values = MathUtility.computeValuesOfLagrangianPolynomialsAtZero(clusterSize);
         BigDecimal N = new BigDecimal(0);
         for (int i = 0; i < nPieceArr.length; i++) {
@@ -380,54 +185,19 @@ public class WorkerMain {
         System.out.println("The modulus is :" + key.getN());
     }
 
-    final Object primalityTestLock = new Object();
-    int primalityTestCounter = 0;
-    boolean primalityTestWaiting = false;
+    public boolean primalityTestWaiting = false;
 
-    private boolean primalityTestHost() {
+    public boolean primalityTestHost() {
         BigInteger g = MathUtility.genRandBig(key.getN(), rnd);
 
         BigInteger[] verificationArray = new BigInteger[this.clusterSize];
 
-        synchronized (primalityTestLock) {
-            primalityTestWaiting = true;
-            primalityTestCounter = 0;
-            for (int i = 0; i < addressBook.length; i++) {
-                StdRequest request = RpcUtility.Request.newStdRequest(id, g);
-                stubs[i].primalityTest(request, new StreamObserver<PrimalityTestResponse>() {
-                    @Override
-                    public void onNext(PrimalityTestResponse value) {
-                        int j = value.getId() - 1;
-                        BigInteger v = new BigInteger(value.getV().toByteArray());
-                        verificationArray[j] = v;
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        System.out.println("primalityTest to Guests RPC Error: " + t.getMessage());
-                        System.exit(-1);
-                    }
-
-                    @Override
-                    public void onCompleted() {
-                        synchronized (primalityTestLock) {
-                            primalityTestCounter++;
-                            if (primalityTestCounter == addressBook.length) {
-                                primalityTestLock.notify();
-                            }
-                        }
-                    }
-                });
-            }
-            System.out.println("Waiting for primality test complete");
-            try {
-                primalityTestLock.wait();
-            } catch (InterruptedException e) {
-                System.out.println("Waiting interrupted: " + e.getMessage());
-                System.exit(-3);
-            }
-            primalityTestWaiting = false;
+        primalityTestWaiting = true;
+        for (int i = 0; i < clusterSize; i++) {
+            rpcSender.sendPrimalityTestRequest(i, g, verificationArray);
         }
+        dataReceiver.waitVerificationFactors();
+        primalityTestWaiting = false;
 
         BigInteger v = BigInteger.valueOf(1);
         for (int i = 1; i < clusterSize; i++) {
@@ -437,7 +207,7 @@ public class WorkerMain {
         return verificationArray[0].equals(v.mod(key.getN()));
     }
 
-    private BigInteger primalityTestGuest(BigInteger g) {
+    public BigInteger primalityTestGuest(BigInteger g) {
         // Todo: change server 1 every time to do load balancing
         if (id == 1) {
             BigInteger exponent = key.getN().subtract(p).subtract(q).add(BigInteger.valueOf(1));
@@ -446,48 +216,24 @@ public class WorkerMain {
         return g.modPow(p.add(q), key.getN());
     }
 
-    final Object exchangeGammaLock = new Object();
-    int exchangeGammaCounter = 0;
     BigInteger[] gammaArr;
-    final Object exchangeGammaSumLock = new Object();
-    int exchangeGammaSumCounter = 0;
     BigInteger[] gammaSumArr;
 
-    private void generatePrivateKey() {
+    public void generatePrivateKey() {
         // Todo: change server 1 every time to do load balancing
         BigInteger phi = (id == 1) ?
                 key.getN().subtract(p).subtract(q).add(BigInteger.ONE) :
                 BigInteger.ZERO.subtract(p).subtract((q));
         BigInteger[] gammaArrLocal = MathUtility.generateRandomSumArray(phi, clusterSize, rnd);
-        synchronized (exchangeGammaLock) {
-            for (int i = 0; i < clusterSize; i++) {
-                sendGamma(i + 1, gammaArrLocal[i]);
-            }
-            if (exchangeGammaCounter < 2 * clusterSize) {
-                try {
-                    exchangeGammaLock.wait();
-                } catch (Exception e) {
-                    System.out.println(e.getMessage());
-                    System.exit(-1);
-                }
-            }
-            exchangeGammaCounter = 0;
+        for (int i = 0; i < clusterSize; i++) {
+            rpcSender.sendGamma(i + 1, gammaArrLocal[i]);
         }
+        dataReceiver.waitGamma();
         BigInteger gammaSum = MathUtility.arraySum(gammaArr);
-        synchronized (exchangeGammaSumLock) {
-            for (int i = 0; i < clusterSize; i++) {
-                sendGammaSum(i + 1, gammaSum);
-            }
-            if (exchangeGammaSumCounter < 2 * clusterSize) {
-                try {
-                    exchangeGammaSumLock.wait();
-                } catch (Exception e) {
-                    System.out.println(e.getMessage());
-                    System.exit(-1);
-                }
-            }
-            exchangeGammaSumCounter = 0;
+        for (int i = 0; i < clusterSize; i++) {
+            rpcSender.sendGammaSum(i + 1, gammaSum);
         }
+        dataReceiver.waitGammaSum();
         BigInteger l = MathUtility.arraySum(gammaSumArr).mod(key.getE());
 
         BigDecimal zeta = BigDecimal.ONE.divide(new BigDecimal(l), RoundingMode.HALF_UP)
@@ -522,105 +268,13 @@ public class WorkerMain {
         }
     }
 
-    private void sendGamma(int i, BigInteger gamma) {
-        StdRequest request = RpcUtility.Request.newStdRequest(this.id, gamma);
-        stubs[i - 1].exchangeGamma(request, new StreamObserver<StdResponse>() {
-            @Override
-            public void onNext(StdResponse response) {
-//                System.out.println("received by " + response.getId());
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("sendGamma RPC error for " + i + " : " + t.getMessage());
-                System.exit(-1);
-            }
-
-            @Override
-            public void onCompleted() {
-//                System.out.println("sent!");
-                synchronized (exchangeGammaLock) {
-                    exchangeGammaCounter++;
-                    if (exchangeGammaCounter == 2 * clusterSize) {
-                        exchangeGammaLock.notify();
-                    }
-                }
-            }
-        });
-    }
-
-    private void sendGammaSum(int i, BigInteger gammaSum) {
-        StdRequest request = RpcUtility.Request.newStdRequest(this.id, gammaSum);
-        stubs[i - 1].exchangeGammaSum(request, new StreamObserver<StdResponse>() {
-            @Override
-            public void onNext(StdResponse response) {
-//                System.out.println("received by " + response.getId());
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("sendGamma RPC error for " + i + " : " + t.getMessage());
-                System.exit(-1);
-            }
-
-            @Override
-            public void onCompleted() {
-//                System.out.println("sent!");
-                synchronized (exchangeGammaSumLock) {
-                    exchangeGammaSumCounter++;
-                    if (exchangeGammaSumCounter == 2 * clusterSize) {
-                        exchangeGammaSumLock.notify();
-                    }
-                }
-            }
-        });
-    }
-
-    final Object trialDecryptionLock = new Object();
-    boolean trialDecryptionWaiting = false;
-    int trialDecryptionCounter = 0;
-
     private String[] trialDecryption(String encryptedMessage) {
         String[] result = new String[clusterSize];
-        synchronized (trialDecryptionLock) {
-            trialDecryptionWaiting = true;
-            trialDecryptionCounter = 0;
-            for (int i = 1; i < clusterSize; i++) {
-                stubs[i].decrypt(RpcUtility.Request.newStdRequest(id, encryptedMessage),
-                        new StreamObserver<StdResponse>() {
-                            @Override
-                            public void onNext(StdResponse response) {
-                                int j = response.getId() - 1;
-                                result[j] = new String(response.getContents().toByteArray());
-                            }
-
-                            @Override
-                            public void onError(Throwable t) {
-                                System.out.println("trial decryption error: " + t.getMessage());
-                                System.exit(-1);
-                            }
-
-                            @Override
-                            public void onCompleted() {
-                                synchronized (trialDecryptionLock) {
-                                    trialDecryptionCounter++;
-                                    if (trialDecryptionCounter == clusterSize) {
-                                        trialDecryptionLock.notify();
-                                    }
-                                }
-                            }
-                        });
-            }
-            System.out.println("Waiting for trial decryption to complete");
-            try {
-                trialDecryptionLock.wait();
-            } catch (InterruptedException e) {
-                System.out.println("Waiting interrupted: " + e.getMessage());
-                System.exit(-4);
-            }
-            trialDecryptionWaiting = false;
+        for (int i = 1; i < clusterSize; i++) {
+            rpcSender.sendDecryptRequest(i, encryptedMessage, result);
         }
+        System.out.println("Waiting for trial decryption to complete");
+        dataReceiver.waitShadows();
         return result;
     }
-
 }

--- a/app/src/main/java/mpc/project/WorkerMain.java
+++ b/app/src/main/java/mpc/project/WorkerMain.java
@@ -14,9 +14,11 @@ import mpc.project.util.RSA;
 public class WorkerMain {
     private Server server;
     private WorkerRPCSender rpcSender;
-    public WorkerRPCSender getRpcSender(){
+
+    public WorkerRPCSender getRpcSender() {
         return rpcSender;
     }
+
     private WorkerDataReceiver dataReceiver;
 
     public WorkerDataReceiver getDataReceiver() {
@@ -44,7 +46,7 @@ public class WorkerMain {
         dataBucketInit();
     }
 
-    public int getClusterSize(){
+    public int getClusterSize() {
         return clusterSize;
     }
 
@@ -64,7 +66,8 @@ public class WorkerMain {
      *    private key: <d, N>
      */
     private Key key = new Key();
-    public Key getKey(){
+
+    public Key getKey() {
         return key;
     }
 
@@ -109,8 +112,9 @@ public class WorkerMain {
     }
 
     private final Object modulusGenerationLock = new Object();
+
     public void generateModulusPiece(int bitNum, BigInteger randomPrime) {
-        synchronized (modulusGenerationLock){
+        synchronized (modulusGenerationLock) {
             p = BigInteger.probablePrime(bitNum, rnd);
             q = BigInteger.probablePrime(bitNum, rnd);
             generateFGH(randomPrime);
@@ -226,7 +230,7 @@ public class WorkerMain {
                 BigInteger.ZERO.subtract(p).subtract((q));
         BigInteger[] gammaArrLocal = MathUtility.generateRandomSumArray(phi, clusterSize, rnd);
         for (int i = 1; i <= clusterSize; i++) {
-            rpcSender.sendGamma(i, gammaArrLocal[i]);
+            rpcSender.sendGamma(i, gammaArrLocal[i - 1]);
         }
         dataReceiver.waitGamma();
         BigInteger gammaSum = MathUtility.arraySum(gammaArr);

--- a/app/src/main/java/mpc/project/WorkerMain.java
+++ b/app/src/main/java/mpc/project/WorkerMain.java
@@ -38,7 +38,6 @@ public class WorkerMain {
 
     private final Random rnd;
 
-    private WorkerServiceGrpc.WorkerServiceStub[] stubs;
     private int clusterSize;
 
     public void setClusterSize(int clusterSize) {
@@ -49,8 +48,6 @@ public class WorkerMain {
     public int getClusterSize() {
         return clusterSize;
     }
-
-    private ManagerServiceGrpc.ManagerServiceBlockingStub managerStub;
 
     /* Variables for distributed RSA keypair generation */
     private BigInteger p;

--- a/app/src/main/java/mpc/project/WorkerMain.java
+++ b/app/src/main/java/mpc/project/WorkerMain.java
@@ -193,7 +193,7 @@ public class WorkerMain {
         BigInteger[] verificationArray = new BigInteger[this.clusterSize];
 
         primalityTestWaiting = true;
-        for (int i = 0; i < clusterSize; i++) {
+        for (int i = 1; i <= clusterSize; i++) {
             rpcSender.sendPrimalityTestRequest(i, g, verificationArray);
         }
         dataReceiver.waitVerificationFactors();
@@ -225,13 +225,13 @@ public class WorkerMain {
                 key.getN().subtract(p).subtract(q).add(BigInteger.ONE) :
                 BigInteger.ZERO.subtract(p).subtract((q));
         BigInteger[] gammaArrLocal = MathUtility.generateRandomSumArray(phi, clusterSize, rnd);
-        for (int i = 0; i < clusterSize; i++) {
-            rpcSender.sendGamma(i + 1, gammaArrLocal[i]);
+        for (int i = 1; i <= clusterSize; i++) {
+            rpcSender.sendGamma(i, gammaArrLocal[i]);
         }
         dataReceiver.waitGamma();
         BigInteger gammaSum = MathUtility.arraySum(gammaArr);
-        for (int i = 0; i < clusterSize; i++) {
-            rpcSender.sendGammaSum(i + 1, gammaSum);
+        for (int i = 1; i <= clusterSize; i++) {
+            rpcSender.sendGammaSum(i, gammaSum);
         }
         dataReceiver.waitGammaSum();
         BigInteger l = MathUtility.arraySum(gammaSumArr).mod(key.getE());
@@ -270,7 +270,7 @@ public class WorkerMain {
 
     private String[] trialDecryption(String encryptedMessage) {
         String[] result = new String[clusterSize];
-        for (int i = 1; i < clusterSize; i++) {
+        for (int i = 1; i <= clusterSize; i++) {
             rpcSender.sendDecryptRequest(i, encryptedMessage, result);
         }
         System.out.println("Waiting for trial decryption to complete");

--- a/app/src/main/java/mpc/project/WorkerRPCReceiverService.java
+++ b/app/src/main/java/mpc/project/WorkerRPCReceiverService.java
@@ -9,26 +9,15 @@ import mpc.project.util.RpcUtility;
 import java.math.BigInteger;
 
 public class WorkerRPCReceiverService extends WorkerServiceGrpc.WorkerServiceImplBase {
-    private WorkerMain worker;
+    final private WorkerMain worker;
     private int id;
 
     public WorkerRPCReceiverService(WorkerMain worker) {
         this.worker = worker;
     }
 
-    /* Variables for distributed RSA keypair generation */
-    private BigInteger randomPrime;
-    //    private BigInteger p;
-//    private BigInteger q;
-    private BigInteger[] pArr;          // An array holding p_i ( i \in [1, clusterNum])
-    private BigInteger[] qArr;          // An array holding q_i ( i \in [1, clusterNum])
-    private BigInteger[] hArr;          // An array holding h_i ( i \in [1, clusterNum])
-    private BigInteger[] nPieceArr;
-
     @Override
     public void formCluster(StdRequest request, StreamObserver<StdResponse> responseObserver) {
-//            id = request.getId();
-//            randomPrime = new BigInteger(request.getContents().toByteArray());
         StdResponse res = RpcUtility.Response.newStdResponse(id);
         responseObserver.onNext(res);
         responseObserver.onCompleted();
@@ -60,8 +49,6 @@ public class WorkerRPCReceiverService extends WorkerServiceGrpc.WorkerServiceImp
         String managerUri = new String(request.getContents().toByteArray());
         Channel channel = ManagedChannelBuilder.forTarget(managerUri).usePlaintext().build();
         worker.getRpcSender().setManagerStub(ManagerServiceGrpc.newBlockingStub(channel));
-//        StdRequest greetingReq = RpcUtility.Request.newStdRequest(id);
-//        managerStub.greeting(greetingReq);
         responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
         responseObserver.onCompleted();
         System.out.println("registered manager at " + managerUri);

--- a/app/src/main/java/mpc/project/WorkerRPCReceiverService.java
+++ b/app/src/main/java/mpc/project/WorkerRPCReceiverService.java
@@ -1,0 +1,151 @@
+package mpc.project;
+
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import mpc.project.util.RSA;
+import mpc.project.util.RpcUtility;
+
+import java.math.BigInteger;
+
+public class WorkerRPCReceiverService extends WorkerServiceGrpc.WorkerServiceImplBase {
+    private WorkerMain worker;
+    private int id;
+
+    public WorkerRPCReceiverService(WorkerMain worker) {
+        this.worker = worker;
+    }
+
+    /* Variables for distributed RSA keypair generation */
+    private BigInteger randomPrime;
+    //    private BigInteger p;
+//    private BigInteger q;
+    private BigInteger[] pArr;          // An array holding p_i ( i \in [1, clusterNum])
+    private BigInteger[] qArr;          // An array holding q_i ( i \in [1, clusterNum])
+    private BigInteger[] hArr;          // An array holding h_i ( i \in [1, clusterNum])
+    private BigInteger[] nPieceArr;
+
+    @Override
+    public void formCluster(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+//            id = request.getId();
+//            randomPrime = new BigInteger(request.getContents().toByteArray());
+        StdResponse res = RpcUtility.Response.newStdResponse(id);
+        responseObserver.onNext(res);
+        responseObserver.onCompleted();
+        System.out.println("connected to Manager");
+    }
+
+    @Override
+    public void formNetwork(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        String midString = new String(request.getContents().toByteArray());
+        String[] addressBook = midString.split(";");
+        StdResponse response = RpcUtility.Response.newStdResponse(id);
+        WorkerServiceGrpc.WorkerServiceStub[] stubs = new WorkerServiceGrpc.WorkerServiceStub[addressBook.length];
+        System.out.println("received and parsed addressBook: ");
+        for (int i = 0; i < addressBook.length; i++) {
+            System.out.println(addressBook[i]);
+            Channel channel = ManagedChannelBuilder.forTarget(addressBook[i]).usePlaintext().build();
+            stubs[i] = WorkerServiceGrpc.newStub(channel);
+        }
+        worker.getRpcSender().setStubs(stubs);
+        worker.setClusterSize(addressBook.length);
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void registerManager(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        worker.setId(request.getId());
+        this.id = request.getId();
+        String managerUri = new String(request.getContents().toByteArray());
+        Channel channel = ManagedChannelBuilder.forTarget(managerUri).usePlaintext().build();
+        worker.getRpcSender().setManagerStub(ManagerServiceGrpc.newBlockingStub(channel));
+//        StdRequest greetingReq = RpcUtility.Request.newStdRequest(id);
+//        managerStub.greeting(greetingReq);
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
+        responseObserver.onCompleted();
+        System.out.println("registered manager at " + managerUri);
+    }
+
+    @Override
+    public void generateModulusPiece(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        // id is used for bitNum now, not id
+        int bitNum = request.getId();
+        BigInteger randomPrime = new BigInteger(request.getContents().toByteArray());
+        worker.generateModulusPiece(bitNum, randomPrime);
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void exchangePrimesPQH(ExchangePrimespqhRequest request, StreamObserver<StdResponse> responseObserver) {
+        int id = request.getId();
+        BigInteger p = new BigInteger(request.getP().toByteArray());
+        BigInteger q = new BigInteger(request.getQ().toByteArray());
+        BigInteger h = new BigInteger(request.getH().toByteArray());
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
+        responseObserver.onCompleted();
+        worker.getDataReceiver().receivePHQ(id, p, q, h);
+    }
+
+    @Override
+    public void exchangeNPiece(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        int id = request.getId();
+        BigInteger nPiece = new BigInteger(request.getContents().toByteArray());
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
+        responseObserver.onCompleted();
+        worker.getDataReceiver().receiveNPiece(id, nPiece);
+    }
+
+    @Override
+    public void primalityTest(StdRequest request, StreamObserver<PrimalityTestResponse> responseObserver) {
+//            System.out.println("receive primalityTest RPC");
+        if (id == 1 && !worker.primalityTestWaiting) {
+            boolean passPrimalityTest = worker.primalityTestHost();
+            PrimalityTestResponse response;
+            if (passPrimalityTest) {
+                response = RpcUtility.Response.newPrimalityTestResponse(1);
+            } else {
+                response = RpcUtility.Response.newPrimalityTestResponse(0);
+            }
+            responseObserver.onNext(response);
+        } else {
+            BigInteger result = worker.primalityTestGuest(new BigInteger(request.getContents().toByteArray()));
+            responseObserver.onNext(RpcUtility.Response.newPrimalityTestResponse(id, result));
+        }
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void exchangeGamma(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        int id = request.getId();
+        BigInteger gamma = new BigInteger(request.getContents().toByteArray());
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
+        responseObserver.onCompleted();
+        worker.getDataReceiver().receiveGamma(id, gamma);
+    }
+
+    @Override
+    public void exchangeGammaSum(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        int id = request.getId();
+        BigInteger gammaSum = new BigInteger(request.getContents().toByteArray());
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
+        responseObserver.onCompleted();
+        worker.getDataReceiver().receiveGammaSum(id, gammaSum);
+    }
+
+    @Override
+    public void generatePrivateKey(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        worker.generatePrivateKey();
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void decrypt(StdRequest request, StreamObserver<StdResponse> responseObserver) {
+        String encryptedString = new String(request.getContents().toByteArray());
+        String shadow = RSA.localDecrypt(encryptedString, worker.getKey());
+        responseObserver.onNext(RpcUtility.Response.newStdResponse(id, shadow));
+        responseObserver.onCompleted();
+    }
+}

--- a/app/src/main/java/mpc/project/WorkerRPCSender.java
+++ b/app/src/main/java/mpc/project/WorkerRPCSender.java
@@ -1,0 +1,149 @@
+package mpc.project;
+
+import io.grpc.stub.StreamObserver;
+import mpc.project.util.RpcUtility;
+
+import java.math.BigInteger;
+
+public class WorkerRPCSender {
+    private WorkerServiceGrpc.WorkerServiceStub[] stubs;
+    private ManagerServiceGrpc.ManagerServiceBlockingStub managerStub;
+
+    public void setManagerStub(ManagerServiceGrpc.ManagerServiceBlockingStub managerStub) {
+        this.managerStub = managerStub;
+    }
+
+    private WorkerMain worker;
+    public WorkerRPCSender(WorkerMain worker){
+        this.worker = worker;
+    }
+
+    public void setStubs(WorkerServiceGrpc.WorkerServiceStub[] stubs) {
+        this.stubs = stubs;
+    }
+
+    public void sendPQH(int i, BigInteger p, BigInteger q, BigInteger h) {
+        ExchangePrimespqhRequest request = RpcUtility.Request.newExchangePrimesRequest(worker.getId(), p, q, h);
+        stubs[i - 1].exchangePrimesPQH(request, new StreamObserver<>() {
+            @Override
+            public void onNext(StdResponse response) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                System.out.println("exchangePQH RPC error for " + i + " : " + t.getMessage());
+                System.exit(-1);
+            }
+
+            @Override
+            public void onCompleted() {
+//                System.out.println("sent!");
+            }
+        });
+    }
+
+    public void sendNPiece(int i, BigInteger nPiece) {
+        StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), nPiece);
+        stubs[i - 1].exchangeNPiece(request, new StreamObserver<StdResponse>() {
+            @Override
+            public void onNext(StdResponse response) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                System.out.println("sendNPiece RPC error for " + i + " : " + t.getMessage());
+                System.exit(-1);
+            }
+
+            @Override
+            public void onCompleted() {
+//                System.out.println("sent!");
+            }
+        });
+    }
+
+    public void sendPrimalityTestRequest(int i, BigInteger g, BigInteger[] resultBucket) {
+        StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), g);
+        stubs[i].primalityTest(request, new StreamObserver<PrimalityTestResponse>() {
+            @Override
+            public void onNext(PrimalityTestResponse value) {
+                int id = value.getId();
+                BigInteger v = new BigInteger(value.getV().toByteArray());
+                worker.getDataReceiver().receiveVerificationFactor(id, v, resultBucket);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                System.out.println("primalityTest to Guests RPC Error: " + t.getMessage());
+                System.exit(-1);
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+    }
+
+    public void sendGamma(int i, BigInteger gamma) {
+        StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gamma);
+        stubs[i - 1].exchangeGamma(request, new StreamObserver<StdResponse>() {
+            @Override
+            public void onNext(StdResponse response) {
+//                System.out.println("received by " + response.getId());
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                System.out.println("sendGamma RPC error for " + i + " : " + t.getMessage());
+                System.exit(-1);
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+    }
+
+    public void sendGammaSum(int i, BigInteger gammaSum) {
+        StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gammaSum);
+        stubs[i - 1].exchangeGammaSum(request, new StreamObserver<StdResponse>() {
+            @Override
+            public void onNext(StdResponse response) {
+//                System.out.println("received by " + response.getId());
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                System.out.println("sendGamma RPC error for " + i + " : " + t.getMessage());
+                System.exit(-1);
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+    }
+
+    public void sendDecryptRequest(int i, String encryptedMessage, String[] resultBucket){
+        stubs[i].decrypt(RpcUtility.Request.newStdRequest(worker.getId(), encryptedMessage),
+                new StreamObserver<StdResponse>() {
+                    @Override
+                    public void onNext(StdResponse response) {
+                        int id = response.getId();
+                        String shadow = new String(response.getContents().toByteArray());
+                        worker.getDataReceiver().receiveShadow(id, shadow, resultBucket);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        System.out.println("trial decryption error: " + t.getMessage());
+                        System.exit(-1);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+
+                    }
+                });
+    }
+}

--- a/app/src/main/java/mpc/project/WorkerRPCSender.java
+++ b/app/src/main/java/mpc/project/WorkerRPCSender.java
@@ -1,5 +1,6 @@
 package mpc.project;
 
+import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
 import mpc.project.util.RpcUtility;
 
@@ -14,7 +15,8 @@ public class WorkerRPCSender {
     }
 
     private WorkerMain worker;
-    public WorkerRPCSender(WorkerMain worker){
+
+    public WorkerRPCSender(WorkerMain worker) {
         this.worker = worker;
     }
 
@@ -24,126 +26,151 @@ public class WorkerRPCSender {
 
     public void sendPQH(int id, BigInteger p, BigInteger q, BigInteger h) {
         ExchangePrimespqhRequest request = RpcUtility.Request.newExchangePrimesRequest(worker.getId(), p, q, h);
-        stubs[id - 1].exchangePrimesPQH(request, new StreamObserver<>() {
-            @Override
-            public void onNext(StdResponse response) {
-            }
+        Context ctx = Context.current().fork();
+        ctx.run(() -> {
+            stubs[id - 1].exchangePrimesPQH(request, new StreamObserver<>() {
+                @Override
+                public void onNext(StdResponse response) {
+                }
 
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("exchangePQH RPC error for " + id + " : " + t.getMessage());
-                System.exit(-1);
-            }
+                @Override
+                public void onError(Throwable t) {
+                    t.printStackTrace();
+                    System.out.println("exchangePQH RPC error for " + id + " : " + t.getMessage());
+                    System.exit(-1);
+                }
 
-            @Override
-            public void onCompleted() {
+                @Override
+                public void onCompleted() {
 //                System.out.println("sent!");
-            }
+                }
+            });
         });
+
     }
 
     public void sendNPiece(int id, BigInteger nPiece) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), nPiece);
-        stubs[id - 1].exchangeNPiece(request, new StreamObserver<StdResponse>() {
-            @Override
-            public void onNext(StdResponse response) {
-            }
+        Context ctx = Context.current().fork();
+        ctx.run(() -> {
+            stubs[id - 1].exchangeNPiece(request, new StreamObserver<StdResponse>() {
+                @Override
+                public void onNext(StdResponse response) {
+                }
 
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("sendNPiece RPC error for " + id + " : " + t.getMessage());
-                System.exit(-1);
-            }
+                @Override
+                public void onError(Throwable t) {
+                    t.printStackTrace();
+                    System.out.println("sendNPiece RPC error for " + id + " : " + t.getMessage());
+                    System.exit(-1);
+                }
 
-            @Override
-            public void onCompleted() {
+                @Override
+                public void onCompleted() {
 //                System.out.println("sent!");
-            }
+                }
+            });
         });
     }
 
     public void sendPrimalityTestRequest(int id, BigInteger g, BigInteger[] resultBucket) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), g);
-        stubs[id-1].primalityTest(request, new StreamObserver<PrimalityTestResponse>() {
-            @Override
-            public void onNext(PrimalityTestResponse value) {
-                int id = value.getId();
-                BigInteger v = new BigInteger(value.getV().toByteArray());
-                worker.getDataReceiver().receiveVerificationFactor(id, v, resultBucket);
-            }
+        Context ctx = Context.current().fork();
+        ctx.run(() -> {
+            stubs[id - 1].primalityTest(request, new StreamObserver<PrimalityTestResponse>() {
+                @Override
+                public void onNext(PrimalityTestResponse value) {
+                    int id = value.getId();
+                    BigInteger v = new BigInteger(value.getV().toByteArray());
+                    worker.getDataReceiver().receiveVerificationFactor(id, v, resultBucket);
+                }
 
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("primalityTest to Guests RPC Error: " + t.getMessage());
-                System.exit(-1);
-            }
+                @Override
+                public void onError(Throwable t) {
+                    t.printStackTrace();
+                    System.out.println("primalityTest to Guests RPC Error: " + t.getMessage());
+                    System.exit(-1);
+                }
 
-            @Override
-            public void onCompleted() {
-            }
+                @Override
+                public void onCompleted() {
+                }
+            });
         });
     }
 
     public void sendGamma(int id, BigInteger gamma) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gamma);
-        stubs[id - 1].exchangeGamma(request, new StreamObserver<StdResponse>() {
-            @Override
-            public void onNext(StdResponse response) {
+        Context ctx = Context.current().fork();
+        ctx.run(() -> {
+            stubs[id - 1].exchangeGamma(request, new StreamObserver<StdResponse>() {
+                @Override
+                public void onNext(StdResponse response) {
 //                System.out.println("received by " + response.getId());
-            }
+                }
 
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
-                System.exit(-1);
-            }
+                @Override
+                public void onError(Throwable t) {
+                    t.printStackTrace();
+                    System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
+                    System.exit(-1);
+                }
 
-            @Override
-            public void onCompleted() {
-            }
+                @Override
+                public void onCompleted() {
+                }
+            });
         });
     }
 
     public void sendGammaSum(int id, BigInteger gammaSum) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gammaSum);
-        stubs[id - 1].exchangeGammaSum(request, new StreamObserver<StdResponse>() {
-            @Override
-            public void onNext(StdResponse response) {
+        Context ctx = Context.current().fork();
+        ctx.run(() -> {
+            stubs[id - 1].exchangeGammaSum(request, new StreamObserver<StdResponse>() {
+                @Override
+                public void onNext(StdResponse response) {
 //                System.out.println("received by " + response.getId());
-            }
+                }
 
-            @Override
-            public void onError(Throwable t) {
-                System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
-                System.exit(-1);
-            }
+                @Override
+                public void onError(Throwable t) {
+                    t.printStackTrace();
+                    System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
+                    System.exit(-1);
+                }
 
-            @Override
-            public void onCompleted() {
-            }
+                @Override
+                public void onCompleted() {
+                }
+            });
         });
     }
 
-    public void sendDecryptRequest(int id, String encryptedMessage, String[] resultBucket){
-        stubs[id-1].decrypt(RpcUtility.Request.newStdRequest(worker.getId(), encryptedMessage),
-                new StreamObserver<StdResponse>() {
-                    @Override
-                    public void onNext(StdResponse response) {
-                        int id = response.getId();
-                        String shadow = new String(response.getContents().toByteArray());
-                        worker.getDataReceiver().receiveShadow(id, shadow, resultBucket);
-                    }
+    public void sendDecryptRequest(int id, String encryptedMessage, String[] resultBucket) {
+        Context ctx = Context.current().fork();
+        ctx.run(() -> {
+            stubs[id - 1].decrypt(RpcUtility.Request.newStdRequest(worker.getId(), encryptedMessage),
+                    new StreamObserver<StdResponse>() {
+                        @Override
+                        public void onNext(StdResponse response) {
+                            int id = response.getId();
+                            String shadow = new String(response.getContents().toByteArray());
+                            worker.getDataReceiver().receiveShadow(id, shadow, resultBucket);
+                        }
 
-                    @Override
-                    public void onError(Throwable t) {
-                        System.out.println("trial decryption error: " + t.getMessage());
-                        System.exit(-1);
-                    }
+                        @Override
+                        public void onError(Throwable t) {
+                            t.printStackTrace();
+                            System.out.println("trial decryption error: " + t.getMessage());
+                            System.exit(-1);
+                        }
 
-                    @Override
-                    public void onCompleted() {
+                        @Override
+                        public void onCompleted() {
 
-                    }
-                });
+                        }
+                    });
+        });
     }
 }

--- a/app/src/main/java/mpc/project/WorkerRPCSender.java
+++ b/app/src/main/java/mpc/project/WorkerRPCSender.java
@@ -14,7 +14,7 @@ public class WorkerRPCSender {
         this.managerStub = managerStub;
     }
 
-    private WorkerMain worker;
+    final private WorkerMain worker;
 
     public WorkerRPCSender(WorkerMain worker) {
         this.worker = worker;
@@ -27,150 +27,138 @@ public class WorkerRPCSender {
     public void sendPQH(int id, BigInteger p, BigInteger q, BigInteger h) {
         ExchangePrimespqhRequest request = RpcUtility.Request.newExchangePrimesRequest(worker.getId(), p, q, h);
         Context ctx = Context.current().fork();
-        ctx.run(() -> {
-            stubs[id - 1].exchangePrimesPQH(request, new StreamObserver<>() {
-                @Override
-                public void onNext(StdResponse response) {
-                }
+        ctx.run(() -> stubs[id - 1].exchangePrimesPQH(request, new StreamObserver<>() {
+            @Override
+            public void onNext(StdResponse response) {
+            }
 
-                @Override
-                public void onError(Throwable t) {
-                    t.printStackTrace();
-                    System.out.println("exchangePQH RPC error for " + id + " : " + t.getMessage());
-                    System.exit(-1);
-                }
+            @Override
+            public void onError(Throwable t) {
+                t.printStackTrace();
+                System.out.println("exchangePQH RPC error for " + id + " : " + t.getMessage());
+                System.exit(-1);
+            }
 
-                @Override
-                public void onCompleted() {
+            @Override
+            public void onCompleted() {
 //                System.out.println("sent!");
-                }
-            });
-        });
+            }
+        }));
 
     }
 
     public void sendNPiece(int id, BigInteger nPiece) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), nPiece);
         Context ctx = Context.current().fork();
-        ctx.run(() -> {
-            stubs[id - 1].exchangeNPiece(request, new StreamObserver<StdResponse>() {
-                @Override
-                public void onNext(StdResponse response) {
-                }
+        ctx.run(() -> stubs[id - 1].exchangeNPiece(request, new StreamObserver<>() {
+            @Override
+            public void onNext(StdResponse response) {
+            }
 
-                @Override
-                public void onError(Throwable t) {
-                    t.printStackTrace();
-                    System.out.println("sendNPiece RPC error for " + id + " : " + t.getMessage());
-                    System.exit(-1);
-                }
+            @Override
+            public void onError(Throwable t) {
+                t.printStackTrace();
+                System.out.println("sendNPiece RPC error for " + id + " : " + t.getMessage());
+                System.exit(-1);
+            }
 
-                @Override
-                public void onCompleted() {
+            @Override
+            public void onCompleted() {
 //                System.out.println("sent!");
-                }
-            });
-        });
+            }
+        }));
     }
 
     public void sendPrimalityTestRequest(int id, BigInteger g, BigInteger[] resultBucket) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), g);
         Context ctx = Context.current().fork();
-        ctx.run(() -> {
-            stubs[id - 1].primalityTest(request, new StreamObserver<PrimalityTestResponse>() {
-                @Override
-                public void onNext(PrimalityTestResponse value) {
-                    int id = value.getId();
-                    BigInteger v = new BigInteger(value.getV().toByteArray());
-                    worker.getDataReceiver().receiveVerificationFactor(id, v, resultBucket);
-                }
+        ctx.run(() -> stubs[id - 1].primalityTest(request, new StreamObserver<>() {
+            @Override
+            public void onNext(PrimalityTestResponse value) {
+                int id = value.getId();
+                BigInteger v = new BigInteger(value.getV().toByteArray());
+                worker.getDataReceiver().receiveVerificationFactor(id, v, resultBucket);
+            }
 
-                @Override
-                public void onError(Throwable t) {
-                    t.printStackTrace();
-                    System.out.println("primalityTest to Guests RPC Error: " + t.getMessage());
-                    System.exit(-1);
-                }
+            @Override
+            public void onError(Throwable t) {
+                t.printStackTrace();
+                System.out.println("primalityTest to Guests RPC Error: " + t.getMessage());
+                System.exit(-1);
+            }
 
-                @Override
-                public void onCompleted() {
-                }
-            });
-        });
+            @Override
+            public void onCompleted() {
+            }
+        }));
     }
 
     public void sendGamma(int id, BigInteger gamma) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gamma);
         Context ctx = Context.current().fork();
-        ctx.run(() -> {
-            stubs[id - 1].exchangeGamma(request, new StreamObserver<StdResponse>() {
-                @Override
-                public void onNext(StdResponse response) {
+        ctx.run(() -> stubs[id - 1].exchangeGamma(request, new StreamObserver<>() {
+            @Override
+            public void onNext(StdResponse response) {
 //                System.out.println("received by " + response.getId());
-                }
+            }
 
-                @Override
-                public void onError(Throwable t) {
-                    t.printStackTrace();
-                    System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
-                    System.exit(-1);
-                }
+            @Override
+            public void onError(Throwable t) {
+                t.printStackTrace();
+                System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
+                System.exit(-1);
+            }
 
-                @Override
-                public void onCompleted() {
-                }
-            });
-        });
+            @Override
+            public void onCompleted() {
+            }
+        }));
     }
 
     public void sendGammaSum(int id, BigInteger gammaSum) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gammaSum);
         Context ctx = Context.current().fork();
-        ctx.run(() -> {
-            stubs[id - 1].exchangeGammaSum(request, new StreamObserver<StdResponse>() {
-                @Override
-                public void onNext(StdResponse response) {
+        ctx.run(() -> stubs[id - 1].exchangeGammaSum(request, new StreamObserver<>() {
+            @Override
+            public void onNext(StdResponse response) {
 //                System.out.println("received by " + response.getId());
-                }
+            }
 
-                @Override
-                public void onError(Throwable t) {
-                    t.printStackTrace();
-                    System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
-                    System.exit(-1);
-                }
+            @Override
+            public void onError(Throwable t) {
+                t.printStackTrace();
+                System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
+                System.exit(-1);
+            }
 
-                @Override
-                public void onCompleted() {
-                }
-            });
-        });
+            @Override
+            public void onCompleted() {
+            }
+        }));
     }
 
     public void sendDecryptRequest(int id, String encryptedMessage, String[] resultBucket) {
         Context ctx = Context.current().fork();
-        ctx.run(() -> {
-            stubs[id - 1].decrypt(RpcUtility.Request.newStdRequest(worker.getId(), encryptedMessage),
-                    new StreamObserver<StdResponse>() {
-                        @Override
-                        public void onNext(StdResponse response) {
-                            int id = response.getId();
-                            String shadow = new String(response.getContents().toByteArray());
-                            worker.getDataReceiver().receiveShadow(id, shadow, resultBucket);
-                        }
+        ctx.run(() -> stubs[id - 1].decrypt(RpcUtility.Request.newStdRequest(worker.getId(), encryptedMessage),
+                new StreamObserver<>() {
+                    @Override
+                    public void onNext(StdResponse response) {
+                        int id = response.getId();
+                        String shadow = new String(response.getContents().toByteArray());
+                        worker.getDataReceiver().receiveShadow(id, shadow, resultBucket);
+                    }
 
-                        @Override
-                        public void onError(Throwable t) {
-                            t.printStackTrace();
-                            System.out.println("trial decryption error: " + t.getMessage());
-                            System.exit(-1);
-                        }
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                        System.out.println("trial decryption error: " + t.getMessage());
+                        System.exit(-1);
+                    }
 
-                        @Override
-                        public void onCompleted() {
+                    @Override
+                    public void onCompleted() {
 
-                        }
-                    });
-        });
+                    }
+                }));
     }
 }

--- a/app/src/main/java/mpc/project/WorkerRPCSender.java
+++ b/app/src/main/java/mpc/project/WorkerRPCSender.java
@@ -22,16 +22,16 @@ public class WorkerRPCSender {
         this.stubs = stubs;
     }
 
-    public void sendPQH(int i, BigInteger p, BigInteger q, BigInteger h) {
+    public void sendPQH(int id, BigInteger p, BigInteger q, BigInteger h) {
         ExchangePrimespqhRequest request = RpcUtility.Request.newExchangePrimesRequest(worker.getId(), p, q, h);
-        stubs[i - 1].exchangePrimesPQH(request, new StreamObserver<>() {
+        stubs[id - 1].exchangePrimesPQH(request, new StreamObserver<>() {
             @Override
             public void onNext(StdResponse response) {
             }
 
             @Override
             public void onError(Throwable t) {
-                System.out.println("exchangePQH RPC error for " + i + " : " + t.getMessage());
+                System.out.println("exchangePQH RPC error for " + id + " : " + t.getMessage());
                 System.exit(-1);
             }
 
@@ -42,16 +42,16 @@ public class WorkerRPCSender {
         });
     }
 
-    public void sendNPiece(int i, BigInteger nPiece) {
+    public void sendNPiece(int id, BigInteger nPiece) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), nPiece);
-        stubs[i - 1].exchangeNPiece(request, new StreamObserver<StdResponse>() {
+        stubs[id - 1].exchangeNPiece(request, new StreamObserver<StdResponse>() {
             @Override
             public void onNext(StdResponse response) {
             }
 
             @Override
             public void onError(Throwable t) {
-                System.out.println("sendNPiece RPC error for " + i + " : " + t.getMessage());
+                System.out.println("sendNPiece RPC error for " + id + " : " + t.getMessage());
                 System.exit(-1);
             }
 
@@ -62,9 +62,9 @@ public class WorkerRPCSender {
         });
     }
 
-    public void sendPrimalityTestRequest(int i, BigInteger g, BigInteger[] resultBucket) {
+    public void sendPrimalityTestRequest(int id, BigInteger g, BigInteger[] resultBucket) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), g);
-        stubs[i].primalityTest(request, new StreamObserver<PrimalityTestResponse>() {
+        stubs[id-1].primalityTest(request, new StreamObserver<PrimalityTestResponse>() {
             @Override
             public void onNext(PrimalityTestResponse value) {
                 int id = value.getId();
@@ -84,9 +84,9 @@ public class WorkerRPCSender {
         });
     }
 
-    public void sendGamma(int i, BigInteger gamma) {
+    public void sendGamma(int id, BigInteger gamma) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gamma);
-        stubs[i - 1].exchangeGamma(request, new StreamObserver<StdResponse>() {
+        stubs[id - 1].exchangeGamma(request, new StreamObserver<StdResponse>() {
             @Override
             public void onNext(StdResponse response) {
 //                System.out.println("received by " + response.getId());
@@ -94,7 +94,7 @@ public class WorkerRPCSender {
 
             @Override
             public void onError(Throwable t) {
-                System.out.println("sendGamma RPC error for " + i + " : " + t.getMessage());
+                System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
                 System.exit(-1);
             }
 
@@ -104,9 +104,9 @@ public class WorkerRPCSender {
         });
     }
 
-    public void sendGammaSum(int i, BigInteger gammaSum) {
+    public void sendGammaSum(int id, BigInteger gammaSum) {
         StdRequest request = RpcUtility.Request.newStdRequest(worker.getId(), gammaSum);
-        stubs[i - 1].exchangeGammaSum(request, new StreamObserver<StdResponse>() {
+        stubs[id - 1].exchangeGammaSum(request, new StreamObserver<StdResponse>() {
             @Override
             public void onNext(StdResponse response) {
 //                System.out.println("received by " + response.getId());
@@ -114,7 +114,7 @@ public class WorkerRPCSender {
 
             @Override
             public void onError(Throwable t) {
-                System.out.println("sendGamma RPC error for " + i + " : " + t.getMessage());
+                System.out.println("sendGamma RPC error for " + id + " : " + t.getMessage());
                 System.exit(-1);
             }
 
@@ -124,8 +124,8 @@ public class WorkerRPCSender {
         });
     }
 
-    public void sendDecryptRequest(int i, String encryptedMessage, String[] resultBucket){
-        stubs[i].decrypt(RpcUtility.Request.newStdRequest(worker.getId(), encryptedMessage),
+    public void sendDecryptRequest(int id, String encryptedMessage, String[] resultBucket){
+        stubs[id-1].decrypt(RpcUtility.Request.newStdRequest(worker.getId(), encryptedMessage),
                 new StreamObserver<StdResponse>() {
                     @Override
                     public void onNext(StdResponse response) {

--- a/app/src/main/java/mpc/project/util/MathUtility.java
+++ b/app/src/main/java/mpc/project/util/MathUtility.java
@@ -41,7 +41,7 @@ public class MathUtility {
         return result;
     }
 
-    static public BigInteger genRandBig(int bitLength, Random rnd){
+    static public BigInteger genRandBig(int bitLength, Random rnd) {
         return new BigInteger(bitLength, rnd);
     }
 
@@ -69,29 +69,29 @@ public class MathUtility {
     static public BigInteger[] generateRandomSumArray(BigInteger sum, int size, Random rnd) {
         BigInteger[] result = new BigInteger[size];
         int bigLength = sum.bitLength();
-        for(int i = 0; i < size-1; i++){
+        for (int i = 0; i < size - 1; i++) {
             BigInteger num = genRandBig(bigLength, rnd);
-            if(rnd.nextBoolean()){
+            if (rnd.nextBoolean()) {
                 num = num.negate();
             }
             result[i] = num;
         }
-        result[size-1] = BigInteger.ZERO;
-        result[size-1] = sum.subtract(arraySum(result));
+        result[size - 1] = BigInteger.ZERO;
+        result[size - 1] = sum.subtract(arraySum(result));
         return result;
     }
 
-    static public BigInteger arrayProduct(BigInteger[] array){
+    static public BigInteger arrayProduct(BigInteger[] array) {
         BigInteger result = BigInteger.ONE;
-        for(BigInteger element : array){
+        for (BigInteger element : array) {
             result = result.multiply(element);
         }
         return result;
     }
 
-    static public BigInteger[] toBigIntegerArray(long[] array){
+    static public BigInteger[] toBigIntegerArray(long[] array) {
         BigInteger[] result = new BigInteger[array.length];
-        for(int i = 0; i < array.length; i++){
+        for (int i = 0; i < array.length; i++) {
             result[i] = BigInteger.valueOf(array[i]);
         }
         return result;

--- a/app/src/main/java/mpc/project/util/MathUtility.java
+++ b/app/src/main/java/mpc/project/util/MathUtility.java
@@ -34,7 +34,7 @@ public class MathUtility {
     }
 
     static public BigInteger genRandPrimeBig(int bitNum, BigInteger lessThanThis, Random rnd) {
-        BigInteger result = BigInteger.valueOf(0);
+        BigInteger result;
         do {
             result = BigInteger.probablePrime(bitNum, rnd);
         } while (result.compareTo(lessThanThis) >= 0);

--- a/app/src/main/java/mpc/project/util/MathUtility.java
+++ b/app/src/main/java/mpc/project/util/MathUtility.java
@@ -80,4 +80,20 @@ public class MathUtility {
         result[size-1] = sum.subtract(arraySum(result));
         return result;
     }
+
+    static public BigInteger arrayProduct(BigInteger[] array){
+        BigInteger result = BigInteger.ONE;
+        for(BigInteger element : array){
+            result = result.multiply(element);
+        }
+        return result;
+    }
+
+    static public BigInteger[] toBigIntegerArray(long[] array){
+        BigInteger[] result = new BigInteger[array.length];
+        for(int i = 0; i < array.length; i++){
+            result[i] = BigInteger.valueOf(array[i]);
+        }
+        return result;
+    }
 }

--- a/app/src/main/java/mpc/project/util/Sieving.java
+++ b/app/src/main/java/mpc/project/util/Sieving.java
@@ -1,0 +1,38 @@
+package mpc.project.util;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+public class Sieving {
+    final static long[] sievedPrimesLong = {
+            2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 43, 47
+    };
+    final static BigInteger[] sievedPrimes = MathUtility.toBigIntegerArray(sievedPrimesLong);
+    final static BigInteger M = MathUtility.arrayProduct(sievedPrimes);
+    final static int probeBucketSize = 31;
+
+    static public BigInteger generateSievedA(Random rnd) {
+        BigInteger a = null;
+        boolean foundGoodCandidate = false;
+        do {
+            BigInteger r = MathUtility.genRandBig(M, rnd);
+            for (int i = 0; i < probeBucketSize; i++) {
+                BigInteger target = r.add(BigInteger.valueOf((long) i));
+                boolean noKnownFactor = true;
+                for (BigInteger prime : sievedPrimes) {
+                    if (target.remainder(prime).equals(BigInteger.ZERO)) {
+                        noKnownFactor = false;
+                        break;
+                    }
+                }
+                if (noKnownFactor) {
+                    foundGoodCandidate = true;
+                    a = target;
+                    break;
+                }
+            }
+        } while (!foundGoodCandidate);
+
+        return a;
+    }
+}


### PR DESCRIPTION
```WorkerMain``` is split into ```WorkerMain```, ```WorkerRPCReceiverService```, ```WorkerRPCSender``` and ```WorkerDataReceiver```.

The name is self-explanatory. ```WorkerMain``` handles the main logic, ```WorkerRPCReceiverService``` handles income RPC requests, ```WorkerRPCSender``` handles outgoing RPC requests and ```WorkerDataReceiver``` handles the data sent by both RPC responses and RPC requests. 

During refactoring, a problem of random cancelation of RPC calls raised. It's likely solved by a context fork before worker sending outgoing RPC requests but more tests are to be done. 
